### PR TITLE
Remove `release_displays`

### DIFF
--- a/code.py
+++ b/code.py
@@ -32,7 +32,6 @@ except ImportError:
     config = None
 
 # setup display
-displayio.release_displays()
 try:
     adafruit_fruitjam.peripherals.request_display_config()  # user display configuration
 except ValueError:  # invalid user config or no user config provided


### PR DESCRIPTION
I've experienced display instability when loading an application using this template from Fruit Jam OS. Looking at other programs which don't have this issue, it seems that they're not using `displayio.release_displays()`. I've omitted that here in this update. I'll need to do further testing to prove that this fixes the instability problem.