### PR TITLE
Add Blinka support for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.vscode
 dist
 .DS_Store

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Install Blinka",
+            "type": "shell",
+            "command": "pip3 install -r requirements-blinka.txt",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Run Blinka",
+            "type": "shell",
+            "command": "python3 code.py",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 # Fruit_Jam_Application
 Template for a CircuitPython application for the Adafruit Fruit Jam which is compatible with Fruit Jam OS.
 
-## Building
+## Building CircuitPython Package
 Ensure that you have python 3.x installed system-wide and all the prerequisite libraries installed using the following command:
 
 ``` shell
-pip install circup requests
+pip3 install circup requests
 ```
 
 Download all CircuitPython libraries and package the application using the following command:
 
 ``` shell
-python build/build.py
+python3 build/build.py
 ```
 
 The project bundle should be found within `./dist` as a `.zip` file with the same name as your repository.
+
+## Testing with Blinka
+Ensure that you have python 3.x installed system-wide and all the prerequisite libraries installed using the following command:
+
+``` shell
+pip3 install -r requirements-blinka.txt
+```
+
+Run the program using the following command:
+
+``` shell
+python3 code.py
+```
+
+A application window for the program will open and support input from keyboard, mouse, and supported gamepads.

--- a/code.py
+++ b/code.py
@@ -123,7 +123,7 @@ if BLINKA:
 
     def handle_event(event) -> None:
         if event.type == pygame.KEYDOWN:
-            handle_key(event.unicode)
+            handle_key(event.unicode.upper())
 
         elif event.type == pygame.MOUSEMOTION:
             mouse_tg.x = event.pos[0] // DISPLAY_SCALE
@@ -192,7 +192,7 @@ else:
                         if buffer and buffer[0] == "~":
                             key += buffer[0]
                             buffer = buffer[1:]
-                    handle_key(key)
+                    handle_key(key.upper())
             
             # mouse input
             if mouse is not None and mouse.update() is not None:

--- a/code.py
+++ b/code.py
@@ -17,85 +17,198 @@ if len(__file__.split("/")[:-1]) > 1:
 import atexit
 import displayio
 import sys
-import supervisor
 from terminalio import FONT
+import time
 
+import adafruit_imageload
 from adafruit_display_text.label import Label
-import adafruit_fruitjam.peripherals
-from adafruit_usb_host_mouse import find_and_init_boot_mouse
+import adafruit_usb_host_mouse
+import relic_usb_host_gamepad
 
-# get Fruit Jam OS config if available
+DISPLAY_REFRESH = 60
+DISPLAY_WIDTH = 720
+DISPLAY_HEIGHT = 400
+
 try:
-    import launcher_config
-    config = launcher_config.LauncherConfig()
+    import supervisor
+
 except ImportError:
-    config = None
+    import pygame
+    from blinka_displayio_pygamedisplay import PyGameDisplay
+    import relic_usb_host_gamepad.pygame
 
-# setup display
-try:
-    adafruit_fruitjam.peripherals.request_display_config()  # user display configuration
-except ValueError:  # invalid user config or no user config provided
-    adafruit_fruitjam.peripherals.request_display_config(720, 400)  # default display size
-display = supervisor.runtime.display
+    BLINKA = True
+    DISPLAY_SCALE = 2
 
-# setup audio, buttons, and neopixels
-peripherals = adafruit_fruitjam.peripherals.Peripherals(
-    safe_volume_limit=(config.audio_volume_override_danger if config is not None else 0.75),
-)
+else:
+    import adafruit_fruitjam.peripherals
 
-# user-defined audio output and volume
-peripherals.audio_output = config.audio_output if config is not None else "headphone"
-peripherals.volume = config.audio_volume if config is not None else 0.7
+    BLINKA = False
+    DISPLAY_SCALE = 1
+
+if BLINKA:
+
+    display = PyGameDisplay(
+        width=DISPLAY_WIDTH*DISPLAY_SCALE, height=DISPLAY_HEIGHT*DISPLAY_SCALE,  # default display size
+        icon="icon.bmp",
+        caption="Application",
+        native_frames_per_second=DISPLAY_REFRESH,
+    )
+
+else:
+
+    # get Fruit Jam OS config if available
+    try:
+        import launcher_config
+        config = launcher_config.LauncherConfig()
+    except ImportError:
+        config = None
+
+    # setup display
+    try:
+        adafruit_fruitjam.peripherals.request_display_config()  # user display configuration
+    except ValueError:  # invalid user config or no user config provided
+        adafruit_fruitjam.peripherals.request_display_config(DISPLAY_WIDTH, DISPLAY_HEIGHT)  # default display size
+    display = supervisor.runtime.display
+    DISPLAY_WIDTH, DISPLAY_HEIGHT = display.width, display.height
+
+    # setup audio, buttons, and neopixels
+    peripherals = adafruit_fruitjam.peripherals.Peripherals(
+        safe_volume_limit=(config.audio_volume_override_danger if config is not None else 0.75),
+    )
+
+    # user-defined audio output and volume
+    peripherals.audio_output = config.audio_output if config is not None else "headphone"
+    peripherals.volume = config.audio_volume if config is not None else 0.7
 
 # create root group
-root_group = displayio.Group()
+root_group = displayio.Group(scale=DISPLAY_SCALE)
 display.root_group = root_group
 
 # example text
 root_group.append(Label(
     font=FONT, text="Hello, World!",
     anchor_point=(0.5, 0.5),
-    anchored_position=(display.width//2, display.height//2),
+    anchored_position=(DISPLAY_WIDTH//2, DISPLAY_HEIGHT//2),
 ))
 
-# mouse device
-mouse = None
-if config is not None and config.use_mouse and (mouse := find_and_init_boot_mouse()) is not None:
-    root_group.append(mouse.tilegrid)
+def handle_key(key: str) -> None:
+    pass
 
-def atexit_callback() -> None:
-    if mouse and mouse.was_attached and not mouse.device.is_kernel_driver_active(0):
-        mouse.device.attach_kernel_driver(0)
-atexit.register(atexit_callback)
+def handle_click(button: str, x: int, y: int) -> None:
+    pass
 
-# flush input buffer
-while supervisor.runtime.serial_bytes_available:
-    sys.stdin.read(1)
+def handle_button(id: int, pressed: bool) -> None:
+    pass
 
-try:
-    previous_pressed_btns = None
-    while True:
+def update() -> None:
+    pass
 
-        # keyboard input
-        keys = []
-        if (available := supervisor.runtime.serial_bytes_available) > 0:
-            buffer = sys.stdin.read(available)
-            while buffer:
-                key = buffer[0]
-                buffer = buffer[1:]
-                if key == "\x1b" and buffer and buffer[0] == "[" and len(buffer) >= 2:
-                    key += buffer[:2]
-                    buffer = buffer[2:]
-                    if buffer and buffer[0] == "~":
-                        key += buffer[0]
-                        buffer = buffer[1:]
-                keys.append(key.upper())
-        
-        # mouse input
-        if mouse is not None and mouse.update() is not None:
-            if "left" in mouse.pressed_btns and (previous_pressed_btns is None or "left" not in previous_pressed_btns):
-                pass  # left click
-            previous_pressed_btns = mouse.pressed_btns
+if BLINKA:
 
-except KeyboardInterrupt:
-    peripherals.deinit()
+    # setup mouse cursor
+    mouse_bitmap, mouse_palette = adafruit_imageload.load(
+        "/".join(adafruit_usb_host_mouse.__file__.split("/")[:-1]) + "/mouse_cursor.bmp",
+        bitmap=displayio.Bitmap, palette=displayio.Palette
+    )
+    mouse_palette.make_transparent(0)
+    mouse_tg = displayio.TileGrid(
+        bitmap=mouse_bitmap, pixel_shader=mouse_palette,
+        x=DISPLAY_WIDTH//2, y=DISPLAY_HEIGHT//2,
+    )
+    root_group.append(mouse_tg)
+
+    # gamepad device
+    gamepad = relic_usb_host_gamepad.pygame.Gamepad()
+
+    def handle_event(event) -> None:
+        if event.type == pygame.KEYDOWN:
+            handle_key(event.unicode)
+
+        elif event.type == pygame.MOUSEMOTION:
+            mouse_tg.x = event.pos[0] // DISPLAY_SCALE
+            mouse_tg.y = event.pos[1] // DISPLAY_SCALE
+
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            for i, btn in enumerate(adafruit_usb_host_mouse.BUTTONS):
+                if event.button & (1 << i):
+                    handle_click(btn, mouse_tg.x, mouse_tg.y)
+                    break
+                    
+        else:
+            gamepad.process_event(event)
+
+    def prepare_update() -> None:
+        for event in gamepad.events:
+            handle_button(event.key_number, event.pressed)
+        update()
+        gamepad.reset_button_changes()
+
+    display.event_loop(
+        on_time=prepare_update,
+        on_event=handle_event,
+        events=(
+            pygame.KEYDOWN,
+            pygame.KEYUP,
+            pygame.MOUSEMOTION,
+            pygame.MOUSEBUTTONDOWN,
+        ) + relic_usb_host_gamepad.pygame.EVENT_TYPES,
+        delay=1 / DISPLAY_REFRESH,
+    )
+
+else:
+
+    # mouse device
+    mouse = None
+    if config is not None and config.use_mouse and (mouse := adafruit_usb_host_mouse.find_and_init_boot_mouse()) is not None:
+        root_group.append(mouse.tilegrid)
+
+    def atexit_callback() -> None:
+        if mouse and mouse.was_attached and not mouse.device.is_kernel_driver_active(0):
+            mouse.device.attach_kernel_driver(0)
+    atexit.register(atexit_callback)
+
+    # gamepad device
+    gamepad = relic_usb_host_gamepad.Gamepad()
+
+    # flush input buffer
+    while supervisor.runtime.serial_bytes_available:
+        sys.stdin.read(1)
+
+    try:
+        previous_pressed_btns = None
+        last_timestamp = time.monotonic()
+        while True:
+
+            # keyboard input
+            if (available := supervisor.runtime.serial_bytes_available) > 0:
+                buffer = sys.stdin.read(available)
+                while buffer:
+                    key = buffer[0]
+                    buffer = buffer[1:]
+                    if key == "\x1b" and buffer and buffer[0] == "[" and len(buffer) >= 2:
+                        key += buffer[:2]
+                        buffer = buffer[2:]
+                        if buffer and buffer[0] == "~":
+                            key += buffer[0]
+                            buffer = buffer[1:]
+                    handle_key(key)
+            
+            # mouse input
+            if mouse is not None and mouse.update() is not None:
+                for btn in mouse.pressed_btns:
+                    if previous_pressed_btns is None or btn not in previous_pressed_btns:
+                        handle_click(btn, mouse.x, mouse.y)
+                previous_pressed_btns = mouse.pressed_btns
+
+            # gamepad input
+            if gamepad.update():
+                for event in gamepad.events:
+                    handle_button(event.key_number, event.pressed)
+
+            if (current_timestamp := time.monotonic()) - last_timestamp >= 1 / DISPLAY_REFRESH:
+                update()
+                last_timestamp = current_timestamp
+
+    except KeyboardInterrupt:
+        peripherals.deinit()

--- a/requirements-blinka.txt
+++ b/requirements-blinka.txt
@@ -1,0 +1,7 @@
+adafruit-blinka
+adafruit-blinka-displayio
+adafruit-circuitpython-display-text
+adafruit-circuitpython-imageload
+adafruit-circuitpython-usb-host-mouse
+blinka-displayio-pygamedisplay
+circuitpython-usb-host-gamepad


### PR DESCRIPTION
This update depends on version 1.3.0 of `relic_usb_host_gamepad` (https://github.com/relic-se/CircuitPython_USB_Host_Gamepad/releases/tag/1.3.0) and depends on changes implemented within https://github.com/adafruit/Adafruit_CircuitPython_USB_Host_Mouse/pull/17.